### PR TITLE
CodeQL - Bazel build support 

### DIFF
--- a/.github/workflows/codeql-analysis-bazel.yml
+++ b/.github/workflows/codeql-analysis-bazel.yml
@@ -53,9 +53,10 @@ jobs:
           bazel clean --expunge
 
           # Build using the following Bazel flags, to help CodeQL detect the build:
+          # `--spawn_strategy=local`: build locally, instead of using a distributed build
           # `--nouse_action_cache`: turn off build caching, which might prevent recompilation of source code
           # `--noremote_accept_cached`, `--noremote_upload_local_results`: avoid using a remote cache
-          bazel build --nouse_action_cache --noremote_accept_cached --noremote_upload_local_results //:app
+          bazel build --spawn_strategy=local --nouse_action_cache --noremote_accept_cached --noremote_upload_local_results //:app
 
-      - name: Perform CodeQL Analysis
+      - name: Finalize and Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis-bazel.yml
+++ b/.github/workflows/codeql-analysis-bazel.yml
@@ -14,6 +14,10 @@ name: "Code Scanning - Bazel"
 on:
   push:
     branches: [ main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+  workflow_dispatch:    
 
 jobs:
   CodeQL-Build:

--- a/.github/workflows/codeql-analysis-bazel.yml
+++ b/.github/workflows/codeql-analysis-bazel.yml
@@ -21,8 +21,6 @@ on:
 
 jobs:
   CodeQL-Build:
-    # If you're only analyzing JavaScript or Python, CodeQL runs on ubuntu-latest, windows-latest, and macos-latest.
-    # If you're analyzing C/C++, C#, Go, or Java, CodeQL runs on ubuntu-latest, windows-2019, and macos-latest.
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/codeql-analysis-bazel.yml
+++ b/.github/workflows/codeql-analysis-bazel.yml
@@ -37,26 +37,6 @@ jobs:
 
       - uses: bazelbuild/setup-bazelisk@v2
 
-      # Initializes the CodeQL tools for scanning.
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
-        with:
-          languages: java
-          debug: true
-
-      - name: CodeQL trace build step
+      - name: Build
         run: |
-          set -x
-          
-          # Before building, remove cached objects
-          # and stop all running Bazel server processes.
-          bazel clean --expunge
-
-          # Build using the following Bazel flags, to help CodeQL detect the build:
-          # `--spawn_strategy=local`: build locally, instead of using a distributed build
-          # `--nouse_action_cache`: turn off build caching, which might prevent recompilation of source code
-          # `--noremote_accept_cached`, `--noremote_upload_local_results`: avoid using a remote cache
-          bazel build --spawn_strategy=local --nouse_action_cache --noremote_accept_cached --noremote_upload_local_results //:app
-
-      - name: Finalize and Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+          bazel build //:app     

--- a/.github/workflows/codeql-analysis-bazel.yml
+++ b/.github/workflows/codeql-analysis-bazel.yml
@@ -38,11 +38,11 @@ jobs:
       - uses: bazelbuild/setup-bazelisk@v2
 
       # Initializes the CodeQL tools for scanning.
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
-        with:
-          languages: java
-          debug: true
+      #- name: Initialize CodeQL
+      #  uses: github/codeql-action/init@v2
+      #  with:
+      #    languages: java
+      #    debug: true
 
       - name: CodeQL trace build step
         run: |
@@ -50,5 +50,5 @@ jobs:
           
           bazel build //:app
 
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+      #- name: Perform CodeQL Analysis
+      #  uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis-bazel.yml
+++ b/.github/workflows/codeql-analysis-bazel.yml
@@ -44,22 +44,7 @@ jobs:
         run: |
           set -x
           
-          # REF: https://codeql.github.com/docs/codeql-cli/creating-codeql-databases/
-          
-          # Before building, remove cached objects
-          # and stop all running Bazel server processes.
-          bazel clean --expunge
-
-          # Build using the following Bazel flags, to help CodeQL detect the build:
-          # `--spawn_strategy=local`: build locally, instead of using a distributed build
-          # `--nouse_action_cache`: turn off build caching, which might prevent recompilation of source code
-          # `--noremote_accept_cached`, `--noremote_upload_local_results`: avoid using a remote cache     
-          bazel build --spawn_strategy=local --nouse_action_cache --noremote_accept_cached --noremote_upload_local_results //:app
-
-          # After building, stop all running Bazel server processes.
-          # This ensures future build commands start in a clean Bazel server process
-          # without CodeQL attached.
-          bazel shutdown
+          bazel build //:app
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis-bazel.yml
+++ b/.github/workflows/codeql-analysis-bazel.yml
@@ -34,7 +34,48 @@ jobs:
         uses: actions/checkout@v2
 
       - uses: bazelbuild/setup-bazelisk@v2
+      
+          # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL - Init DB and start trace
+        uses: github/codeql-action/init@v2
+        with:
+          languages: java
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
+
+
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      #- name: Autobuild
+      #  uses: github/codeql-action/autobuild@v2
+
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+      #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
       - name: Build
         run: |
-          bazel build //:app     
+          # Before building, remove cached objects
+          # and stop all running Bazel server processes.
+          bazel clean --expunge
+
+          # Build using the following Bazel flags, to help CodeQL detect the build:
+          # `--spawn_strategy=local`: build locally, instead of using a distributed build
+          # `--nouse_action_cache`: turn off build caching, which might prevent recompilation of source code
+          # `--noremote_accept_cached`, `--noremote_upload_local_results`: avoid using a remote cache
+          bazel build --spawn_strategy=local --nouse_action_cache --noremote_accept_cached --noremote_upload_local_results //:app
+          
+          # After building, stop all running Bazel server processes.
+          # This ensures future build commands start in a clean Bazel server process
+          # without CodeQL attached.
+          bazel shutdown
+
+      - name: Finalize the CodeQL DB - Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+
+ 

--- a/.github/workflows/codeql-analysis-bazel.yml
+++ b/.github/workflows/codeql-analysis-bazel.yml
@@ -38,17 +38,24 @@ jobs:
       - uses: bazelbuild/setup-bazelisk@v2
 
       # Initializes the CodeQL tools for scanning.
-      #- name: Initialize CodeQL
-      #  uses: github/codeql-action/init@v2
-      #  with:
-      #    languages: java
-      #    debug: true
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: java
+          debug: true
 
       - name: CodeQL trace build step
         run: |
           set -x
           
-          bazel build //:app
+          # Before building, remove cached objects
+          # and stop all running Bazel server processes.
+          bazel clean --expunge
 
-      #- name: Perform CodeQL Analysis
-      #  uses: github/codeql-action/analyze@v2
+          # Build using the following Bazel flags, to help CodeQL detect the build:
+          # `--nouse_action_cache`: turn off build caching, which might prevent recompilation of source code
+          # `--noremote_accept_cached`, `--noremote_upload_local_results`: avoid using a remote cache
+          bazel build --nouse_action_cache --noremote_accept_cached --noremote_upload_local_results //:app
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Use CodeQL build tracing with Bazel build


# CodeQL Initialization / Analysis Workflow
<img width="591" alt="image" src="https://user-images.githubusercontent.com/1760475/179284940-d1748887-e6c1-4a9f-bd1c-c5c26a1ce9cc.png">

# Bazel Optimization Guardrails
 required build flags: https://codeql.github.com/docs/codeql-cli/creating-codeql-databases/

- Local Build Subprocess
- Disable Build Caching

# Can I build distributed / across different machines?
Sadly we do not support distributed / cross-machine compiling due to the fact CodeQL needs to hook into the build process and then create the TRAP files for each compiled component.

```
# Build using the following Bazel flags, to help CodeQL detect the build:
# `--spawn_strategy=local`: build locally, instead of using a distributed build
```

# Can I use Bazel caching?
We do not currently support caching in an easy to use way. This requires maintaining a cached copy of the [TRAP files](https://codeql.github.com/docs/codeql-overview/codeql-glossary/#trap-file) generated by CodeQL from previous Bazel builds, knowing which part is associated with which and which parts need to be newly created. 

```
# Before building, remove cached objects
# and stop all running Bazel server processes.
bazel clean --expunge

# Build using the following Bazel flags, to help CodeQL detect the build:

# `--nouse_action_cache`: turn off build caching, which might prevent recompilation of source code
# `--noremote_accept_cached`, `--noremote_upload_local_results`: avoid using a remote cache
```


# Build Failure Scenarios

## Caching Enabled
* [Extractor Error - checking cached actions](https://github.com/vulna-felickz/quickjavahelloworld/runs/7359912617?check_suite_focus=true#step:5:64)

```
[3 / 5] checking cached actions
ERROR: /home/runner/.cache/bazel/_bazel_runner/3111506feaafb81adfb8b1d6fd092246/external/bazel_tools/tools/jdk/BUILD:336:14: JavaToolchainCompileClasses external/bazel_tools/tools/jdk/platformclasspath_classes/DumpPlatformClassPath.class failed: (Exit 1): javac failed: error executing command external/remotejdk11_linux/bin/javac -source 8 -target 8 -Xlint:-options -cp external/remotejdk11_linux/lib/tools.jar -d ... (remaining 2 arguments skipped)
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
[ODASA Javac] Failed to execute ODASA javac builder: java.lang.IllegalArgumentException: FileUtil.makeUniqueName(/home/runner/work/_temp/codeql_databases/java/log/ext,"javac.orig"):  directory /home/runner/work/_temp/codeql_databases/java/log/ext does not exist.
[WARN] Failed to create log file in /home/runner/work/_temp/codeql_databases/java/log
Exception in thread "main" java.lang.Error: Fatal extractor error detected. Attempting to abort build commands.
	at com.semmle.extractor.java.interceptors.JavacMainInterceptor.javacMainResult(JavacMainInterceptor.java:48)
	at jdk.compiler/com.sun.tools.javac.main.Main.SEMMLE_INTERCEPT$9(Main.java)
	at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:323)
	at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:170)
	at jdk.compiler/com.sun.tools.javac.Main.compile(Main.java:57)
	at jdk.compiler/com.sun.tools.javac.Main.main(Main.java:43)
[5 / 7] checking cached actions
Target //:app failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 25.148s, Critical Path: 1.24s
INFO: 5 processes: 5 internal.
FAILED: Build did NOT complete successfully
FAILED: Build did NOT complete successfully
Error: Process completed with exit code 1.
```

## Distributed Build Enabled
* [Extractor Error - Prepa](https://github.com/vulna-felickz/quickjavahelloworld/runs/7360390648?check_suite_focus=true#step:5:69)

```
[4 / 7] [Prepa] JavaToolchainCompileClasses external/bazel_tools/tools/jdk/platformclasspath_classes/DumpPlatformClassPath.class
ERROR: /home/runner/.cache/bazel/_bazel_runner/3111506feaafb81adfb8b1d6fd092246/external/bazel_tools/tools/jdk/BUILD:336:14: JavaToolchainCompileClasses external/bazel_tools/tools/jdk/platformclasspath_classes/DumpPlatformClassPath.class failed: (Exit 1): javac failed: error executing command external/remotejdk11_linux/bin/javac -source 8 -target 8 -Xlint:-options -cp external/remotejdk11_linux/lib/tools.jar -d ... (remaining 2 arguments skipped)
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
[ODASA Javac] Failed to execute ODASA javac builder: java.lang.IllegalArgumentException: FileUtil.makeUniqueName(/home/runner/work/_temp/codeql_databases/java/log/ext,"javac.orig"):  directory /home/runner/work/_temp/codeql_databases/java/log/ext does not exist.
Exception in thread "main" java.lang.Error: Fatal extractor error detected. Attempting to abort build commands.
	at com.semmle.extractor.java.interceptors.JavacMainInterceptor.javacMainResult(JavacMainInterceptor.java:48)
	at jdk.compiler/com.sun.tools.javac.main.Main.SEMMLE_INTERCEPT$9(Main.java)
[WARN] Failed to create log file in /home/runner/work/_temp/codeql_databases/java/log
	at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:323)
	at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:1[70](https://github.com/vulna-felickz/quickjavahelloworld/runs/7360390648?check_suite_focus=true#step:5:71))
	at jdk.compiler/com.sun.tools.javac.Main.compile(Main.java:57)
	at jdk.compiler/com.sun.tools.javac.Main.main(Main.java:43)
Target //:app failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 21.685s, Critical Path: 1.03s
INFO: 5 processes: 5 internal.
FAILED: Build did NOT complete successfully
FAILED: Build did NOT complete successfully
Error: Process completed with exit code 1.
```

## Bazel version compatibility
* [Low/No Successfully extracted files](https://github.com/vulna-felickz/quickjavahelloworld/runs/6802928496?check_suite_focus=true#step:8:52)

```
Analysis produced the following diagnostic data:
|          Diagnostic          |  Summary  |
+------------------------------+-----------+
| Extraction errors            | 0 results |
| Extraction warnings          | 0 results |
| Successfully extracted files | 0 results |
```